### PR TITLE
Feature/python logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ fnv = "1.0.7"
 indicatif = {version = "*", features = ["rayon"]}
 rayon = {version = "1.8.0" }
 noodles-bgzf = { version = "0.25.0", features = ["libdeflate"] }
+log = "0.4"
+pyo3-log = "0.9.0"
 
 [features]
 extension-module = ["pyo3/extension-module"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cnv_from_bam"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -17,6 +17,7 @@ indicatif = {version = "*", features = ["rayon"]}
 rayon = {version = "1.8.0" }
 noodles-bgzf = { version = "0.25.0", features = ["libdeflate"] }
 log = "0.4"
+
 pyo3-log = "0.9.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,46 @@ ax.set_xlim((0, total))
 ```
 Should look something like this. Obviously the cnv data is just a dictionary of lists, so you can do whatever you want with it vis a vis matplotlib, seaborn, etc.
 ![example cnv plot](https://github.com/Adoni5/cnv_from_bam/blob/10a2b00a8832b46cacbff0e2f775a4f440844da0/example_cnv.png?raw=true)
+
+## Output
+### Progress Bar
+By default, a progress bar is displayed, showing the progress of the iteration of each BAM file. To disable the progress bar, set the `CI` environment variable to `1` in your python script:
+
+```python
+import os
+os.environ["CI"] = "1"
+```
+
+### Logging
+We use PyO3-log for rust/python interop logging. By default, the log level is set to `INFO`.
+
+> [!WARN]
+> It is required to set up a logger before a call to `iterate_bam_file` is made. If no logger is set up, the program will not output anything. To set up a logger, run the following code before calling `iterate_bam_file`:
+
+```python
+import logging
+import sys
+FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+logging.basicConfig(format=FORMAT)
+logger = logging.getLogger("cnv_from_bam")
+logger.handlers.clear()
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+```
+
+It is possible to hide the log messages by setting the log level to `WARN`:
+
+```python
+import logging
+import sys
+FORMAT = '%(levelname)s %(name)s %(asctime)-15s %(filename)s:%(lineno)d %(message)s'
+logging.basicConfig(format=FORMAT)
+logger = logging.getLogger("cnv_from_bam")
+logger.handlers.clear()
+logger.setLevel(logging.WARN)
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))
+```
+
 ## Documentation
 
 To generate the documentation, run:
@@ -119,7 +159,7 @@ pre-commit install -t pre-commit -t post-checkout -t post-merge
 pre-commit run --all-files
 ```
 
-```bash
+
 
 ## License
 


### PR DESCRIPTION
We now use pyO3-log to log any messages. 
This means a python logger must be configured before a call to `iterate_bam_file` and message can be filtered out by changing the log level to a higher filter.

We also allow the disabling of the progress bar, by setting the `CI` environment variable. 
